### PR TITLE
Chore/03 change extension name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 図書館で借りる - Chrome 拡張機能
+# KOSEN-OPAC-Checker
 
 Amazon・楽天ブックスの書籍ページに図書館の蔵書情報を自動的に表示する Chrome 拡張機能です。
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "図書館で借りる",
+  "name": "KOSEN-OPAC-Checker",
   "version": "1.2",
   "description": "Amazon・楽天市場の書籍ページに図書館の蔵書情報を表示します",
   "permissions": ["activeTab", "storage"],
@@ -28,7 +28,7 @@
   },
   "action": {
     "default_popup": "popup.html",
-    "default_title": "図書館で借りる"
+    "default_title": "KOSEN-OPAC-Checker"
   },
   "icons": {
     "16": "icons/icon16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "KOSEN-OPAC-Checker",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Amazon・楽天市場の書籍ページに図書館の蔵書情報を表示します",
   "permissions": ["activeTab", "storage"],
   "host_permissions": [

--- a/popup.html
+++ b/popup.html
@@ -147,7 +147,7 @@
   <body>
     <div class="header">
       <div class="logo">📚</div>
-      <h1 class="title">図書館で借りる</h1>
+      <h1 class="title">KOSEN-OPAC-Checker</h1>
       <p class="subtitle">Amazon・楽天市場書籍を図書館で検索</p>
     </div>
 

--- a/popup.js
+++ b/popup.js
@@ -199,7 +199,7 @@ document.addEventListener("DOMContentLoaded", function () {
       document.getElementById("status").style.color = "#007600";
     } else if (url.includes("books.rakuten.co.jp")) {
       document.getElementById("currentPage").textContent =
-        "Rakuten ブックス (書籍ページではありません)";
+        "楽天ブックス (書籍ページではありません)";
       document.getElementById("status").style.color = "#b12704";
     } else {
       document.getElementById("currentPage").textContent =


### PR DESCRIPTION
This pull request updates the extension's branding from Japanese to English, renaming it to "KOSEN-OPAC-Checker" throughout the codebase and user interface. The changes ensure consistency in the extension's name and version, and also update a user-facing message for clarity.

Branding and naming updates:

* Changed the extension name from Japanese ("図書館で借りる") to "KOSEN-OPAC-Checker" in `README.md`, `manifest.json`, `popup.html`, and the extension's default title. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[2]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L3-R4) [[3]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L31-R31) [[4]](diffhunk://#diff-28d0d8f0960f87f8d291caace058de871b8145e54d727271b564eba832123ec8L150-R150)
* Updated the extension version from 1.2 to 1.3 in `manifest.json`.

User interface improvements:

* Changed the Rakuten Books page message to use Japanese ("楽天ブックス") for better localization in `popup.js`.